### PR TITLE
Enhance frontend with dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The CVE Chatbot is a full-stack web application designed to improve cybersecurit
 - **Search by CVE Name:** Retrieve detailed information about a specific CVE.
 - **Search by Keywords:** Look up vulnerabilities using keywords for broader exploration.
 - **Filter by Severity:** Narrow down vulnerabilities by severity levels (Low, Medium, High).
+- **Dark Mode Toggle:** Switch between light and dark themes for comfortable viewing.
 
 ---
 

--- a/static/index.html
+++ b/static/index.html
@@ -7,8 +7,11 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"/>
 </head>
 <body>
-    <h1>CVE Chatbot</h1>
-    <div id="container">
+    <header>
+        <h1>CVE Chatbot</h1>
+        <button id="theme-toggle" aria-label="Toggle theme"><i class="fas fa-moon"></i></button>
+    </header>
+    <main id="container">
         <div id="loading-spinner"></div>
         <div class="section">
         <!--Chat Functionality -->
@@ -32,7 +35,7 @@
 
     <!-- Display Response -->
     <div id="response"></div>
-    </div>
+    </main>
 
     <script src="/static/script.js"></script>
 

--- a/static/script.js
+++ b/static/script.js
@@ -1,11 +1,35 @@
+// Show the loading spinner
+function showSpinner() {
+    document.getElementById('loading-spinner').style.display = 'block';
+}
+
+// Hide the loading spinner
+function hideSpinner() {
+    document.getElementById('loading-spinner').style.display = 'none';
+}
+
+// Fetch helper with basic error handling and spinner support
 async function fetchData(endpoint, data) {
-    const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-    });
-    const result = await response.json();
-    return result.response;
+    showSpinner();
+    try {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Server Error: ${response.status}`);
+        }
+
+        const result = await response.json();
+        return result.response;
+    } catch (error) {
+        console.error('Error fetching data:', error);
+        return `An error occurred: ${error.message}`;
+    } finally {
+        hideSpinner();
+    }
 }
 
 // Search by CVE name
@@ -44,7 +68,7 @@ document.getElementById('filter-btn').addEventListener('click', async () => {
 // Display response in the UI
 function displayResponse(response) {
     const responseDiv = document.getElementById('response');
-    responseDiv.style.display = 'block';
+    responseDiv.style.display = 'grid';
 
     // Clear previous responses
     responseDiv.innerHTML = '';
@@ -69,39 +93,12 @@ function displayResponse(response) {
     });
 }
 
-
-// Show the loading spinner
-function showSpinner() {
-    document.getElementById('loading-spinner').style.display = 'block';
+// Toggle between light and dark themes
+const themeToggle = document.getElementById('theme-toggle');
+if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+        const isDark = document.body.classList.contains('dark-mode');
+        themeToggle.innerHTML = isDark ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+    });
 }
-
-// Hide the loading spinner
-function hideSpinner() {
-    document.getElementById('loading-spinner').style.display = 'none';
-}
-
-// Update fetchData function to show spinner while fetching data
-async function fetchData(endpoint, data) {
-    showSpinner(); // Show spinner
-    try {
-        const response = await fetch(endpoint, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(data),
-        });
-
-        if (!response.ok) {
-            throw new Error(`Server Error: ${response.status}`);
-        }
-
-        const result = await response.json();
-        return result.response;
-    } catch (error) {
-        console.error('Error fetching data:', error);
-        return `An error occurred: ${error.message}`;
-    } finally {
-        hideSpinner(); // Hide spinner
-    }
-}
-
-

--- a/static/style.css
+++ b/static/style.css
@@ -9,10 +9,28 @@ body {
     background-color: #f9f9f9; /* Light gray background */
 }
 
+/* Header */
+header {
+    width: 90%;
+    max-width: 800px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 20px;
+}
+
+#theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    color: #5a67d8;
+}
+
 /* Header styles */
 h1 {
     color: #222;
-    margin-top: 20px;
+    margin: 0;
     font-size: 2.5rem;
     font-weight: bold;
     text-align: center;
@@ -88,6 +106,8 @@ button:active {
     padding: 20px;
     border-radius: 6px;
     display: none;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 15px;
     color: #333;
     font-size: 1rem;
     line-height: 1.5;
@@ -125,6 +145,52 @@ button:active {
     margin: 5px 0;
     font-size: 0.95rem;
     color: #333;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #1a202c;
+    color: #e2e8f0;
+}
+
+body.dark-mode h1,
+body.dark-mode h3 {
+    color: #e2e8f0;
+}
+
+body.dark-mode #container {
+    background: #2d3748;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.5);
+}
+
+body.dark-mode textarea,
+body.dark-mode input {
+    background: #4a5568;
+    color: #e2e8f0;
+    border: 1px solid #718096;
+}
+
+body.dark-mode button {
+    background-color: #3182ce;
+}
+
+body.dark-mode button:hover {
+    background-color: #2b6cb0;
+}
+
+body.dark-mode .response-card {
+    background: #4a5568;
+    border-color: #2d3748;
+    color: #e2e8f0;
+}
+
+body.dark-mode #response {
+    background: #2d3748;
+    color: #e2e8f0;
+}
+
+body.dark-mode #theme-toggle {
+    color: #e2e8f0;
 }
 
 /* Loading spinner */
@@ -177,6 +243,7 @@ button:active {
 @media (max-width: 600px) {
     h1 {
         font-size: 2rem;
+        margin: 0;
     }
 
     #container {


### PR DESCRIPTION
## Summary
- add header with dark mode toggle
- clean up and refactor main JS logic
- style results as a responsive grid
- support dark mode in styles
- document new dark mode feature

## Testing
- `python -m py_compile run.py app/routes.py app/chatbot_model.py app/preprocess_dataset.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a8caa1548330bf7d255919379bd8