### PR TITLE
Improve recruiter-focused UI design

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ The CVE Chatbot is a full-stack web application designed to improve cybersecurit
 
 - **Search by CVE Name:** Retrieve detailed information about a specific CVE.
 - **Search by Keywords:** Look up vulnerabilities using keywords for broader exploration.
-- **Filter by Severity:** Narrow down vulnerabilities by severity levels (Low, Medium, High).
+- **Filter by Severity:** Narrow down vulnerabilities using a convenient drop-down for Low, Medium, High, or Critical levels.
+- **Dark Mode Toggle:** Switch between light and dark themes (preference is saved).
+- **Copy to Clipboard:** Each result card has a copy button for quick sharing.
+- **Scroll-to-Top Button:** Return to the top of the page with one click.
+- **Clear Results:** Quickly clear the chat history and input fields.
+- **Result Count Display:** See how many CVEs match your search.
+- **Responsive Layout:** Works well on mobile and desktop with a clean grid layout.
+- **Modern Styling:** Gradient header and Poppins font give a professional look.
+- **Loading Indicator:** Overlay spinner shows while queries are processed.
 
 ---
 
@@ -39,7 +47,7 @@ python run.py
 The API server will start at http://127.0.0.1:5000.
 
 ## **Access the chatbot:**
-Open the index.html file in your browser to start interacting with the chatbot interface.
+Open the `index.html` file in your browser to start interacting with the chatbot interface. Use the **Clear Results** button to reset fields, the **Copy** buttons to share results, and toggle dark mode using the moon icon. A spinner overlay appears while your request is processed, and a **Top** button helps you quickly return to the beginning of the page.
 
 ## **Acknowledgments**
 - CVE Program for providing the API used in this project.

--- a/static/index.html
+++ b/static/index.html
@@ -2,17 +2,26 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Chatbot for Cybersecurity Awareness</title>
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"/>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
 </head>
 <body>
-    <h1>CVE Chatbot</h1>
-    <div id="container">
-        <div id="loading-spinner"></div>
+    <header>
+        <h1>CVE Chatbot</h1>
+        <p class="tagline">Uncover vulnerabilities effortlessly</p>
+        <button id="theme-toggle" aria-label="Toggle theme"><i class="fas fa-moon"></i></button>
+    </header>
+    <main id="container">
+        <div id="loading-overlay">
+            <div id="loading-spinner"></div>
+        </div>
         <div class="section">
         <!--Chat Functionality -->
         <h3>Search by CVE Name</h3>
+        <label for="cveName" class="visually-hidden">CVE Name</label>
         <textarea id="cveName" placeholder="Enter CVE name"></textarea>
         <button id="chat-btn"> <i class="fas fa-search"></i> Search</button>
         </div>
@@ -20,19 +29,30 @@
      <!--Search by Keyword -->
     <div class="section">
         <h3>Search by Keyword</h3>
+        <label for="keyword" class="visually-hidden">Keyword</label>
         <input type="text" id="keyword" placeholder="Enter keyword">
         <button id="search-btn"><i class="fas fa-key"></i> Search</button>
     </div>
      <!-- Filter by Severity -->
     <div class="section">
             <h3>Filter by Severity</h3>
-            <input type="text" id="severity" placeholder="Enter severity (e.g., Low, Medium, High, Critical)">
+            <label for="severity" class="visually-hidden">Severity</label>
+            <select id="severity">
+                <option value="">Select severity</option>
+                <option value="Low">Low</option>
+                <option value="Medium">Medium</option>
+                <option value="High">High</option>
+                <option value="Critical">Critical</option>
+            </select>
             <button id="filter-btn"><i class="fas fa-filter"></i> Filter</button>
     </div>
 
     <!-- Display Response -->
+    <p id="result-count"></p>
     <div id="response"></div>
-    </div>
+    <button id="clear-btn"><i class="fas fa-trash"></i> Clear Results</button>
+    <button id="top-btn" aria-label="Scroll to top">Top</button>
+    </main>
 
     <script src="/static/script.js"></script>
 

--- a/static/script.js
+++ b/static/script.js
@@ -1,11 +1,35 @@
+// Show the loading spinner
+function showSpinner() {
+    document.getElementById('loading-overlay').style.display = 'flex';
+}
+
+// Hide the loading spinner
+function hideSpinner() {
+    document.getElementById('loading-overlay').style.display = 'none';
+}
+
+// Fetch helper with basic error handling and spinner support
 async function fetchData(endpoint, data) {
-    const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-    });
-    const result = await response.json();
-    return result.response;
+    showSpinner();
+    try {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Server Error: ${response.status}`);
+        }
+
+        const result = await response.json();
+        return result.response;
+    } catch (error) {
+        console.error('Error fetching data:', error);
+        return `An error occurred: ${error.message}`;
+    } finally {
+        hideSpinner();
+    }
 }
 
 // Search by CVE name
@@ -32,9 +56,9 @@ document.getElementById('search-btn').addEventListener('click', async () => {
 
 // Filter by Severity
 document.getElementById('filter-btn').addEventListener('click', async () => {
-    const severity = document.getElementById('severity').value.trim();
+    const severity = document.getElementById('severity').value;
     if (!severity) {
-        alert('Please enter a severity level.');
+        alert('Please select a severity level.');
         return;
     }
     const response = await fetchData('/api/filter', { severity });
@@ -44,7 +68,9 @@ document.getElementById('filter-btn').addEventListener('click', async () => {
 // Display response in the UI
 function displayResponse(response) {
     const responseDiv = document.getElementById('response');
-    responseDiv.style.display = 'block';
+    const countEl = document.getElementById('result-count');
+    responseDiv.style.display = 'grid';
+    countEl.style.display = 'block';
 
     // Clear previous responses
     responseDiv.innerHTML = '';
@@ -52,8 +78,16 @@ function displayResponse(response) {
     // Check if response is a single string
     if (typeof response === 'string') {
         responseDiv.textContent = response;
+        countEl.style.display = 'none';
         return;
     }
+
+    if (!response || response.length === 0) {
+        countEl.textContent = 'No results found.';
+        return;
+    }
+
+    countEl.textContent = `Showing ${response.length} result${response.length !== 1 ? 's' : ''}`;
 
     // Format response as cards (assuming response is an array)
     response.forEach(item => {
@@ -64,44 +98,62 @@ function displayResponse(response) {
             <p><strong>Description:</strong> ${item.description || 'N/A'}</p>
             <p><strong>Severity:</strong> ${item.severity || 'N/A'}</p>
             <p><strong>Published Date:</strong> ${item.date || 'N/A'}</p>
+            <button class="copy-btn" aria-label="Copy details"><i class="fas fa-copy"></i></button>
         `;
+        card.querySelector('.copy-btn').addEventListener('click', () => {
+            navigator.clipboard.writeText(card.innerText).then(() => {
+                card.querySelector('.copy-btn').textContent = 'Copied!';
+                setTimeout(() => {
+                    card.querySelector('.copy-btn').innerHTML = '<i class="fas fa-copy"></i>';
+                }, 1000);
+            });
+        });
         responseDiv.appendChild(card);
     });
+    responseDiv.scrollIntoView({ behavior: 'smooth' });
 }
 
-
-// Show the loading spinner
-function showSpinner() {
-    document.getElementById('loading-spinner').style.display = 'block';
-}
-
-// Hide the loading spinner
-function hideSpinner() {
-    document.getElementById('loading-spinner').style.display = 'none';
-}
-
-// Update fetchData function to show spinner while fetching data
-async function fetchData(endpoint, data) {
-    showSpinner(); // Show spinner
-    try {
-        const response = await fetch(endpoint, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(data),
-        });
-
-        if (!response.ok) {
-            throw new Error(`Server Error: ${response.status}`);
-        }
-
-        const result = await response.json();
-        return result.response;
-    } catch (error) {
-        console.error('Error fetching data:', error);
-        return `An error occurred: ${error.message}`;
-    } finally {
-        hideSpinner(); // Hide spinner
+// Toggle between light and dark themes and persist preference
+const themeToggle = document.getElementById('theme-toggle');
+function applySavedTheme() {
+    const dark = localStorage.getItem('darkMode') === 'true';
+    if (dark) {
+        document.body.classList.add('dark-mode');
+        if (themeToggle) themeToggle.innerHTML = '<i class="fas fa-sun"></i>';
     }
 }
 
+if (themeToggle) {
+    applySavedTheme();
+    themeToggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+        const isDark = document.body.classList.contains('dark-mode');
+        themeToggle.innerHTML = isDark ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+        localStorage.setItem('darkMode', isDark);
+    });
+}
 
+// Clear results and input fields
+const clearBtn = document.getElementById('clear-btn');
+if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+        document.getElementById('response').innerHTML = '';
+        document.getElementById('response').style.display = 'none';
+        document.getElementById('cveName').value = '';
+        document.getElementById('keyword').value = '';
+        document.getElementById('severity').value = '';
+    });
+}
+
+// Scroll-to-top button logic
+const topBtn = document.getElementById('top-btn');
+window.addEventListener('scroll', () => {
+    if (topBtn) {
+        topBtn.style.display = window.scrollY > 300 ? 'block' : 'none';
+    }
+});
+if (topBtn) {
+    topBtn.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,6 @@
 /* General body styles */
 body {
-    font-family: "Roboto", "Ubuntu", sans-serif;
+    font-family: "Poppins", "Roboto", sans-serif;
     margin: 0;
     padding: 0;
     display: flex;
@@ -9,15 +9,55 @@ body {
     background-color: #f9f9f9; /* Light gray background */
 }
 
+/* Header */
+header {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 30px;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+#theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    color: #fff;
+}
+
 /* Header styles */
 h1 {
-    color: #222;
-    margin-top: 20px;
+    color: #fff;
+    margin: 0;
     font-size: 2.5rem;
-    font-weight: bold;
+    font-weight: 600;
     text-align: center;
     letter-spacing: 1px;
     text-transform: uppercase;
+}
+
+.tagline {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 400;
+    color: #f7fafc;
+}
+
+/* Hide labels visually but keep them accessible to screen readers */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Container for sections */
@@ -30,6 +70,7 @@ h1 {
     box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1); /* Subtle shadow */
     border-radius: 8px;
     animation: fadeIn 0.5s ease; /* Fade-in effect */
+    position: relative;
 }
 
 /* Each section */
@@ -39,7 +80,8 @@ h1 {
 
 /* Textarea and input fields */
 textarea,
-input {
+input,
+select {
     width: 100%;
     padding: 12px 16px;
     margin: 10px 0;
@@ -51,7 +93,8 @@ input {
 }
 
 textarea:focus,
-input:focus {
+input:focus,
+select:focus {
     outline: none;
     border: 1px solid #5a67d8; /* Blue focus */
     box-shadow: 0px 0px 4px rgba(90, 103, 216, 0.5); /* Focus shadow */
@@ -81,6 +124,23 @@ button:active {
     transform: scale(0.98); /* Press-down effect */
 }
 
+/* Clear results button */
+#clear-btn {
+    margin-top: 15px;
+    background-color: #e53e3e; /* Red button */
+}
+
+#clear-btn:hover {
+    background-color: #c53030;
+}
+
+/* Result count */
+#result-count {
+    display: none;
+    margin-top: 10px;
+    font-weight: 600;
+}
+
 /* Response box */
 #response {
     margin-top: 20px;
@@ -88,6 +148,8 @@ button:active {
     padding: 20px;
     border-radius: 6px;
     display: none;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 15px;
     color: #333;
     font-size: 1rem;
     line-height: 1.5;
@@ -116,6 +178,38 @@ button:active {
     box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.copy-btn {
+    margin-top: 10px;
+    background-color: #5a67d8;
+    color: #fff;
+    border: none;
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+
+.copy-btn:hover {
+    background-color: #4c51bf;
+}
+
+#top-btn {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    display: none;
+    background-color: #5a67d8;
+    color: #fff;
+    padding: 10px;
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+}
+
+#top-btn:hover {
+    background-color: #4c51bf;
+}
+
 .response-card h4 {
     margin: 0 0 10px;
     color: #5a67d8;
@@ -127,10 +221,104 @@ button:active {
     color: #333;
 }
 
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #1a202c;
+    color: #e2e8f0;
+}
+
+body.dark-mode h1,
+body.dark-mode h3 {
+    color: #e2e8f0;
+}
+
+body.dark-mode .tagline {
+    color: #e2e8f0;
+}
+
+body.dark-mode #container {
+    background: #2d3748;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.5);
+}
+
+body.dark-mode textarea,
+body.dark-mode input {
+    background: #4a5568;
+    color: #e2e8f0;
+    border: 1px solid #718096;
+}
+
+body.dark-mode button {
+    background-color: #3182ce;
+}
+
+body.dark-mode button:hover {
+    background-color: #2b6cb0;
+}
+
+body.dark-mode #clear-btn {
+    background-color: #e53e3e;
+}
+
+body.dark-mode #clear-btn:hover {
+    background-color: #c53030;
+}
+
+body.dark-mode .response-card {
+    background: #4a5568;
+    border-color: #2d3748;
+    color: #e2e8f0;
+}
+
+body.dark-mode .copy-btn {
+    background-color: #3182ce;
+    color: #fff;
+}
+
+body.dark-mode .copy-btn:hover {
+    background-color: #2b6cb0;
+}
+
+body.dark-mode #response {
+    background: #2d3748;
+    color: #e2e8f0;
+}
+
+body.dark-mode #theme-toggle {
+    color: #e2e8f0;
+}
+
+body.dark-mode #result-count {
+    color: #e2e8f0;
+}
+
+body.dark-mode #top-btn {
+    background-color: #3182ce;
+}
+
+body.dark-mode #top-btn:hover {
+    background-color: #2b6cb0;
+}
+
+/* Spinner overlay */
+#loading-overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.7);
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+body.dark-mode #loading-overlay {
+    background: rgba(45, 55, 72, 0.7);
+}
+
 /* Loading spinner */
 #loading-spinner {
-    display: none;
-    margin: 20px auto;
     width: 50px;
     height: 50px;
     border: 6px solid #f3f3f3;
@@ -177,6 +365,7 @@ button:active {
 @media (max-width: 600px) {
     h1 {
         font-size: 2rem;
+        margin: 0;
     }
 
     #container {


### PR DESCRIPTION
## Summary
- use Poppins font and gradient header for a polished look
- add tagline in header and show result count after searches
- update styles for dark mode and new elements
- document new result-count feature and styling in README

## Testing
- `python -m py_compile run.py app/routes.py app/chatbot_model.py app/preprocess_dataset.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844a8caa1548330bf7d255919379bd8